### PR TITLE
Made it a little bit easier to this example into existing projects

### DIFF
--- a/Dear ImGui Sample/ImGuiController.cs
+++ b/Dear ImGui Sample/ImGuiController.cs
@@ -112,8 +112,16 @@ void main()
 }";
             _shader = new Shader("ImGui", VertexSource, FragmentSource);
 
-            // We use unsafe just to be able to do sizeof(...)
-            unsafe { GL.VertexArrayVertexBuffer(_vertexArray, 0, _vertexBuffer, IntPtr.Zero, sizeof(ImDrawVert)); }
+			var imDrawVertSize = 0;
+
+			// public Vector2 pos;
+			imDrawVertSize += 2 * sizeof(float);
+            // public Vector2 uv;
+			imDrawVertSize += 2 * sizeof(float);
+            // public uint col;
+			imDrawVertSize += 1 * sizeof(uint);
+
+            GL.VertexArrayVertexBuffer(_vertexArray, 0, _vertexBuffer, IntPtr.Zero, imDrawVertSize);
             GL.VertexArrayElementBuffer(_vertexArray, _indexBuffer);
 
             GL.EnableVertexArrayAttrib(_vertexArray, 0);
@@ -167,7 +175,7 @@ void main()
         /// <summary>
         /// Updates ImGui input and IO configuration state.
         /// </summary>
-        public void Update(Window wnd, float deltaSeconds)
+        public void Update(GameWindow wnd, float deltaSeconds)
         {
             if (_frameBegun)
             {
@@ -199,7 +207,7 @@ void main()
         KeyboardState PrevKeyboardState;
         readonly List<char> PressedChars = new List<char>();
 
-        private void UpdateImGuiInput(Window wnd)
+        private void UpdateImGuiInput(GameWindow wnd)
         {
             ImGuiIOPtr io = ImGui.GetIO();
 

--- a/Dear ImGui Sample/ImGuiController.cs
+++ b/Dear ImGui Sample/ImGuiController.cs
@@ -112,16 +112,7 @@ void main()
 }";
             _shader = new Shader("ImGui", VertexSource, FragmentSource);
 
-            var imDrawVertSize = 0;
-
-            // public Vector2 pos;
-            imDrawVertSize += 2 * sizeof(float);
-            // public Vector2 uv;
-            imDrawVertSize += 2 * sizeof(float);
-            // public uint col;
-            imDrawVertSize += 1 * sizeof(uint);
-
-            GL.VertexArrayVertexBuffer(_vertexArray, 0, _vertexBuffer, IntPtr.Zero, imDrawVertSize);
+            GL.VertexArrayVertexBuffer(_vertexArray, 0, _vertexBuffer, IntPtr.Zero, Unsafe.SizeOf<ImDrawVert>());
             GL.VertexArrayElementBuffer(_vertexArray, _indexBuffer);
 
             GL.EnableVertexArrayAttrib(_vertexArray, 0);

--- a/Dear ImGui Sample/ImGuiController.cs
+++ b/Dear ImGui Sample/ImGuiController.cs
@@ -95,7 +95,7 @@ void main()
 {
     gl_Position = projection_matrix * vec4(in_position, 0, 1);
     color = in_color;
-	texCoord = in_texCoord;
+    texCoord = in_texCoord;
 }";
             string FragmentSource = @"#version 330 core
 
@@ -112,14 +112,14 @@ void main()
 }";
             _shader = new Shader("ImGui", VertexSource, FragmentSource);
 
-			var imDrawVertSize = 0;
+            var imDrawVertSize = 0;
 
-			// public Vector2 pos;
-			imDrawVertSize += 2 * sizeof(float);
+            // public Vector2 pos;
+            imDrawVertSize += 2 * sizeof(float);
             // public Vector2 uv;
-			imDrawVertSize += 2 * sizeof(float);
+            imDrawVertSize += 2 * sizeof(float);
             // public uint col;
-			imDrawVertSize += 1 * sizeof(uint);
+            imDrawVertSize += 1 * sizeof(uint);
 
             GL.VertexArrayVertexBuffer(_vertexArray, 0, _vertexBuffer, IntPtr.Zero, imDrawVertSize);
             GL.VertexArrayElementBuffer(_vertexArray, _indexBuffer);

--- a/Dear ImGui Sample/Window.cs
+++ b/Dear ImGui Sample/Window.cs
@@ -27,15 +27,18 @@ namespace Dear_ImGui_Sample
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
+
             _controller = new ImGuiController(Width, Height);
         }
 
-        protected override void OnUpdateFrame(FrameEventArgs e)
-        {
-            base.OnUpdateFrame(e);
-        }
-        
-        protected override void OnRenderFrame(FrameEventArgs e)
+		protected override void OnResize(EventArgs e)
+		{
+			base.OnResize(e);
+
+			//_controller.WindowResized(Width, Height);
+		}
+
+		protected override void OnRenderFrame(FrameEventArgs e)
         {
             base.OnRenderFrame(e);
 

--- a/Dear ImGui Sample/Window.cs
+++ b/Dear ImGui Sample/Window.cs
@@ -31,14 +31,14 @@ namespace Dear_ImGui_Sample
             _controller = new ImGuiController(Width, Height);
         }
 
-		protected override void OnResize(EventArgs e)
-		{
-			base.OnResize(e);
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
 
-			//_controller.WindowResized(Width, Height);
-		}
+            //_controller.WindowResized(Width, Height);
+        }
 
-		protected override void OnRenderFrame(FrameEventArgs e)
+        protected override void OnRenderFrame(FrameEventArgs e)
         {
             base.OnRenderFrame(e);
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Dear Imgui Sample using OpenTK
+
+## BadImageFormatexception
+
+If you get the following error you might have to set your platform target to x86:
+
+```
+System.BadImageFormatException: 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
+```
+
+To do that, right click your project (all projects referencing ImGui.NET), click "Properties", click "Build", and change the "Platform target" to "x86".
+
+## Remember to enable/disable OpenGL features after use!
+
+Note that ImGuiController.Render() enables and disables some OpenGL features, such as blending, scissor testing, face culling and depth testing. It also changes the blend equation and blend function. Remember to reset these after you call ImGuiController.Render()!


### PR DESCRIPTION
I forgot to mention it in the commit message, but I also removed the unsafe block to make it easier to just copy/paste the example code into existing projects without having to compile with /unsafe.

Also, I wasn't able to get window resizing to work, hence it is commented out.