### PR TITLE
Fix GL InvalidEnum error

### DIFF
--- a/Dear ImGui Sample/ImGuiController.cs
+++ b/Dear ImGui Sample/ImGuiController.cs
@@ -162,7 +162,7 @@ void main()
             int mips = (int)Math.Floor(Math.Log(Math.Max(width, height), 2));
 
             int prevActiveTexture = GL.GetInteger(GetPName.ActiveTexture);
-            GL.ActiveTexture(0);
+            GL.ActiveTexture(TextureUnit.Texture0);
             int prevTexture2D = GL.GetInteger(GetPName.Texture2D);
 
             _fontTexture = GL.GenTexture();

--- a/Dear ImGui Sample/ImGuiController.cs
+++ b/Dear ImGui Sample/ImGuiController.cs
@@ -163,7 +163,7 @@ void main()
 
             int prevActiveTexture = GL.GetInteger(GetPName.ActiveTexture);
             GL.ActiveTexture(TextureUnit.Texture0);
-            int prevTexture2D = GL.GetInteger(GetPName.Texture2D);
+            int prevTexture2D = GL.GetInteger(GetPName.TextureBinding2D);
 
             _fontTexture = GL.GenTexture();
             GL.BindTexture(TextureTarget.Texture2D, _fontTexture);


### PR DESCRIPTION
GL.ActiveTexture(0); generates a GL_INVALID_ENUM if not used with TextureUnit.Texture0

See Errors section :
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glActiveTexture.xhtml